### PR TITLE
Fix crash on empty state_cmd

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,6 +149,12 @@ cmdSwitchPlatform.prototype.getInitState = function (accessory) {
 cmdSwitchPlatform.prototype.getState = function (thisSwitch, callback) {
   var self = this;
 
+  // Return cached state if no state_cmd provided
+  if (thisSwitch.state_cmd === undefined) {
+    callback(null, thisSwitch.state);
+    return;
+  }
+
   // Execute command to detect state
   exec(thisSwitch.state_cmd, function (error, stdout, stderr) {
     var state = error ? false : true;


### PR DESCRIPTION
According to the documentation state_cmd is supposed
to be optional. Previously the plugin would crash as
it would attempt to run the state_cmd anyway.
This fix is returning the cached state if state_cmd is undefined.

Adresses: https://github.com/luisiam/homebridge-cmdswitch2/issues/31 